### PR TITLE
fix: make anomalydetection summary schema fields nullable

### DIFF
--- a/rust-tvtf/src/funcs/anomalydetection.rs
+++ b/rust-tvtf/src/funcs/anomalydetection.rs
@@ -856,12 +856,12 @@ impl AnomalyDetector {
         summary: SummaryData,
     ) -> anyhow::Result<Option<RecordBatch>> {
         let fields = vec![
-            Arc::new(Field::new("num_anomalies", DataType::Int64, false)),
-            Arc::new(Field::new("thresh", DataType::Float64, false)),
-            Arc::new(Field::new("max_logprob", DataType::Float64, false)),
-            Arc::new(Field::new("min_logprob", DataType::Float64, false)),
-            Arc::new(Field::new("1st_quartile", DataType::Float64, false)),
-            Arc::new(Field::new("3rd_quartile", DataType::Float64, false)),
+            Arc::new(Field::new("num_anomalies", DataType::Int64, true)),
+            Arc::new(Field::new("thresh", DataType::Float64, true)),
+            Arc::new(Field::new("max_logprob", DataType::Float64, true)),
+            Arc::new(Field::new("min_logprob", DataType::Float64, true)),
+            Arc::new(Field::new("1st_quartile", DataType::Float64, true)),
+            Arc::new(Field::new("3rd_quartile", DataType::Float64, true)),
         ];
 
         let schema = Arc::new(Schema::new(fields));

--- a/rust-tvtf/src/funcs/anomalydetection.rs
+++ b/rust-tvtf/src/funcs/anomalydetection.rs
@@ -920,18 +920,14 @@ impl AnomalyDetector {
         output_fields.push(Arc::new(Field::new(
             "log_event_prob",
             DataType::Float64,
-            false,
+            true,
         )));
-        output_fields.push(Arc::new(Field::new("max_freq", DataType::Float64, false)));
-        output_fields.push(Arc::new(Field::new(
-            "probable_cause",
-            DataType::Utf8,
-            false,
-        )));
+        output_fields.push(Arc::new(Field::new("max_freq", DataType::Float64, true)));
+        output_fields.push(Arc::new(Field::new("probable_cause", DataType::Utf8, true)));
         output_fields.push(Arc::new(Field::new(
             "probable_cause_freq",
             DataType::Float64,
-            false,
+            true,
         )));
         let output_schema = Arc::new(Schema::new(output_fields));
 
@@ -1353,18 +1349,14 @@ impl TableFunction for AnomalyDetector {
                 output_fields.push(Arc::new(Field::new(
                     "log_event_prob",
                     DataType::Float64,
-                    false,
+                    true,
                 )));
-                output_fields.push(Arc::new(Field::new("max_freq", DataType::Float64, false)));
-                output_fields.push(Arc::new(Field::new(
-                    "probable_cause",
-                    DataType::Utf8,
-                    false,
-                )));
+                output_fields.push(Arc::new(Field::new("max_freq", DataType::Float64, true)));
+                output_fields.push(Arc::new(Field::new("probable_cause", DataType::Utf8, true)));
                 output_fields.push(Arc::new(Field::new(
                     "probable_cause_freq",
                     DataType::Float64,
-                    false,
+                    true,
                 )));
                 let output_schema = Arc::new(Schema::new(output_fields));
                 self.create_annotated_output(&anomaly_records, &input, output_schema)
@@ -1399,8 +1391,8 @@ mod tests {
     fn test_anomaly_detector_basic() {
         // Create test data with some obvious anomalies
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
         ]));
 
         // Most entries are "success" with 200 (100 times)
@@ -1517,7 +1509,7 @@ mod tests {
 
     #[test]
     fn test_anomaly_detector_empty_input() {
-        let schema = Arc::new(Schema::new(vec![Field::new("col1", DataType::Utf8, false)]));
+        let schema = Arc::new(Schema::new(vec![Field::new("col1", DataType::Utf8, true)]));
         let col = Arc::new(StringArray::from(Vec::<&str>::new())) as ArrayRef;
         let input_batch =
             RecordBatch::try_new(schema, vec![col]).expect("Failed to create record batch");
@@ -1734,8 +1726,8 @@ mod tests {
     #[test]
     fn test_action_summary_output() {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
         ]));
 
         let status_col = Arc::new(StringArray::from(
@@ -1784,8 +1776,8 @@ mod tests {
     #[test]
     fn test_action_annotate_output() {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
         ]));
 
         let status_col = Arc::new(StringArray::from(
@@ -1863,8 +1855,8 @@ mod tests {
     fn test_action_rm_processing() {
         // Test that "rm" (abbreviation for "remove") actually removes anomalies
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
         ]));
 
         let status_col = Arc::new(StringArray::from(
@@ -1919,7 +1911,7 @@ mod tests {
             Arc::new(Schema::new(vec![Field::new(
                 "value",
                 DataType::Float64,
-                false,
+                true,
             )])),
             vec![value_col],
         )
@@ -2001,9 +1993,9 @@ mod tests {
     #[test]
     fn test_specified_fields_filter() {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
-            Field::new("latency", DataType::Float64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
+            Field::new("latency", DataType::Float64, true),
         ]));
 
         let status_col = Arc::new(StringArray::from(
@@ -2050,9 +2042,9 @@ mod tests {
     #[test]
     fn test_specified_fields_annotate() {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
-            Field::new("latency", DataType::Float64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
+            Field::new("latency", DataType::Float64, true),
         ]));
 
         let status_col = Arc::new(StringArray::from(
@@ -2113,8 +2105,8 @@ mod tests {
     #[test]
     fn test_invalid_field_name_returns_error() {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
         ]));
 
         let status_col = Arc::new(StringArray::from(vec!["success"])) as ArrayRef;
@@ -2136,8 +2128,8 @@ mod tests {
     #[test]
     fn test_empty_fields_uses_all_columns() {
         let schema = Arc::new(Schema::new(vec![
-            Field::new("status", DataType::Utf8, false),
-            Field::new("code", DataType::Int64, false),
+            Field::new("status", DataType::Utf8, true),
+            Field::new("code", DataType::Int64, true),
         ]));
 
         let status_col = Arc::new(StringArray::from(


### PR DESCRIPTION
Set summary output fields to nullable to align field definitions with runtime data handling and avoid strict non-null schema constraints.

Made-with: Cursor